### PR TITLE
fix(fourier_2d_rnn.py): correct grid structure for RNN

### DIFF
--- a/fourier_2d_rnn.py
+++ b/fourier_2d_rnn.py
@@ -195,8 +195,8 @@ gridx = gridx.reshape(1, S, 1, 1).repeat([1, 1, S, 1])
 gridy = torch.tensor(np.linspace(0, 1, S), dtype=torch.float)
 gridy = gridy.reshape(1, 1, S, 1).repeat([1, S, 1, 1])
 
-train_a = torch.cat((gridx.repeat([ntrain,1,1,1]), gridy.repeat([ntrain,1,1,1]), train_a), dim=-1)
-test_a = torch.cat((gridx.repeat([ntest,1,1,1]), gridy.repeat([ntest,1,1,1]), test_a), dim=-1)
+train_a = torch.cat(( train_a, gridx.repeat([ntrain,1,1,1]), gridy.repeat([ntrain,1,1,1])), dim=-1)
+test_a = torch.cat((test_a, gridx.repeat([ntest,1,1,1]), gridy.repeat([ntest,1,1,1])), dim=-1)
 
 train_loader = torch.utils.data.DataLoader(torch.utils.data.TensorDataset(train_a, train_u), batch_size=batch_size, shuffle=True)
 test_loader = torch.utils.data.DataLoader(torch.utils.data.TensorDataset(test_a, test_u), batch_size=batch_size, shuffle=False)


### PR DESCRIPTION
The previous version creates data such that the space coordinates are at the starting of the feature list (12 features- 2 space and 10 field). Therefore when we do: 

xx = torch.cat((xx[..., step:-2], im,
                            gridx.repeat([batch_size, 1, 1, 1]), gridy.repeat([batch_size, 1, 1, 1])), dim=-1)

it trims the field features instead of the spatial features, but this is not what we want. We want to trim the spatial features, hence pushing them back helps.